### PR TITLE
fixed install-nepenthes-worker script

### DIFF
--- a/script/install-nepenthes-worker.sh
+++ b/script/install-nepenthes-worker.sh
@@ -54,9 +54,9 @@ if [ $? -ne 0 ]; then
   echo "No multiverse, backing up /etc/apt/sources.list and adding it."
   cp /etc/apt/sources.list /etc/apt/sources.list.pre-nepenthes
   echo "deb http://archive.ubuntu.com/ubuntu `lsb_release -c -s`" \
-    "multiverse" >> /etc/apt.sources.list
+    "multiverse" >> /etc/apt/sources.list
   echo -n "deb http://archive.ubuntu.com/ubuntu `lsb_release -c -s`-updates" \
-    "multiverse" >> /etc/apt.sources.list
+    "multiverse" >> /etc/apt/sources.list
 else
   echo "Multiverse appears to be enabled."
 fi


### PR DESCRIPTION
Install script was failing when multiverse wasn't enabled.
