### PR TITLE
Fix timeout detection

### DIFF
--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -17,8 +17,8 @@ class Scan < ActiveRecord::Base
     empty_ports = []
     have_ports = false
 
-    extrainfo = doc.at('//taskend[@task="SYN Stealth Scan"]/@extrainfo')
-    self.timed_out = extrainfo && extrainfo.value =~ /timed out/
+    timeout = doc.at('//taskend/@extrainfo[contains(., "timed out")]')
+    self.timed_out = !!timeout
     
     doc.xpath('//port').each do |port|
       if port.at('state/@state').value == 'open'


### PR DESCRIPTION
The XML processor was only noting timeouts for "SYN Stealth Scan"
(`-sS`). However, full scans default to "Connect Scan" (`-sT`)
since 10e3637a540a. Change the XPath to trigger for any `<taskend>`
element where the `extrainfo` attribute contains "timed out".
