### PR TITLE
Screenshots schema changes

### DIFF
--- a/db/migrate/20141211183159_change_screenshots_url_to_text.rb
+++ b/db/migrate/20141211183159_change_screenshots_url_to_text.rb
@@ -1,0 +1,13 @@
+class ChangeScreenshotsUrlToText < ActiveRecord::Migration
+  def change
+    reversible do |dir|
+      dir.up do
+        change_column :screenshots, :url, :text
+      end
+
+      dir.down do
+        change_column :screenshots, :url, :string
+      end
+    end
+  end
+end

--- a/db/migrate/20141211200701_index_screenshots_by_screenshotable_id.rb
+++ b/db/migrate/20141211200701_index_screenshots_by_screenshotable_id.rb
@@ -1,0 +1,5 @@
+class IndexScreenshotsByScreenshotableId < ActiveRecord::Migration
+  def change
+    add_index :screenshots, :screenshotable_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140716210124) do
+ActiveRecord::Schema.define(version: 20141211183159) do
 
   create_table "domains", force: true do |t|
     t.string   "name"
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 20140716210124) do
   add_index "scans", ["ip_address_id"], name: "index_scans_on_ip_address_id", using: :btree
 
   create_table "screenshots", force: true do |t|
-    t.string   "url"
+    t.text     "url"
     t.binary   "data",                limit: 16777215
     t.integer  "screenshotable_id"
     t.string   "screenshotable_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141211183159) do
+ActiveRecord::Schema.define(version: 20141211200701) do
 
   create_table "domains", force: true do |t|
     t.string   "name"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 20141211183159) do
   end
 
   add_index "screenshots", ["data_hash"], name: "index_screenshots_on_data_hash", using: :btree
+  add_index "screenshots", ["screenshotable_id"], name: "index_screenshots_on_screenshotable_id", using: :btree
 
   create_table "taggings", force: true do |t|
     t.integer  "tag_id"


### PR DESCRIPTION
Make long screenshot URLs work, and add an index so that screenshot lookup isn't unbearably slow.