### PR TITLE
Fix SSL checking

### DIFF
--- a/app/workers/ssl_results.rb
+++ b/app/workers/ssl_results.rb
@@ -7,13 +7,18 @@ class SslResults
   include Sidekiq::Worker
   sidekiq_options :queue => :results
   
-  def perform(id, ssl_data)
+  def perform(id, ssl_data, status)
     port = Port.find_by_id(id)
     return unless port
     port.settings['ssl_details'] = ssl_data
-    port.ssl = ssl_data.include?('SSL-Session')
+    port.ssl = status == 0
+    # This classifies timeout as non-SSL, which is not always true, but
+    # there are too many non-SSL ports which time out to do anything else.
     
     if cert_match = ssl_data.match(CERT_REGEX)
+      port.ssl = true
+      # Override the return code if we actually have a cert.
+      # This can happen if there's something wrong with the SSL config.
       cert = OpenSSL::X509::Certificate.new(cert_match[0])
       expiry_date = cert.not_after.to_s
       port.notes ||= ''

--- a/app/workers/ssl_worker.rb
+++ b/app/workers/ssl_worker.rb
@@ -9,8 +9,8 @@ class SslWorker
       raise 'Please install coreutils.'
     end
     ssl_data, status = Open3.capture2($TIMEOUT_PATH, '2', $OPENSSL_PATH,
-      's_client', '-connect', "#{host}:#{port}", '-showcerts')
+      's_client', '-connect', "#{host}:#{port}", '-showcerts', stdin_data: '')
     ssl_data.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace)
-    Sidekiq::Client.enqueue(SslResults, id, ssl_data)
+    Sidekiq::Client.enqueue(SslResults, id, ssl_data, status.exitstatus)
   end
 end


### PR DESCRIPTION
Pass an empty input to the OpenSSL command, and check the exit status.

The previous approach of looking for `SSL-Session` is no longer
reliable, since that gets printed in some cases even if we didn't
establish a TLS connection. Instead, pass an empty string as the input
so a successful connection will terminate immediately. This allows us to
determine if the port uses TLS by looking at the return value:

0:   Successful connection
1:   Error of some sort
124: Timed out

Also, if we found a certificate in the output, mark the port as using
TLS. This can be important if the port fails to meet OpenSSL's security
standards or requires a client certificate, in which case the return
code will indicate an error. It's possible that we should use this as
our sole indicator; I'm not sure if there are any cases where a server
certificate will not be displayed for a valid connection.

Remaining issues:

- If a TLS port fails to respond quickly enough, it will be classified
  as non-TLS. I think this is unavoidable because many non-TLS ports
  time out without causing errors.