### PR TITLE
Update gem install with proper bundler version

### DIFF
--- a/script/install-nepenthes-server.sh
+++ b/script/install-nepenthes-server.sh
@@ -68,10 +68,10 @@ git clone https://github.com/aschmitz/nepenthes.git
 cd nepenthes
 
 echo -e "\n[*] Installing Bundler"
-gem install --no-rdoc --no-ri bundler
+gem install --no-rdoc --no-ri bundler -v 1.16.0
 
 echo -e "\n[*] Installing Nepenthes' required gems"
-bundle install --without remote
+bundle _1.16.0_ install --without remote
 
 echo -e "\n[*] Setting a session secret"
 echo "Nepenthes::Application.config.secret_token = \"`rake secret`\"" > \

--- a/script/install-nepenthes-worker.sh
+++ b/script/install-nepenthes-worker.sh
@@ -88,10 +88,10 @@ chmod 0777 log
 cp config/auth.yml.example config/auth.yml
 
 echo -e "\n[*] Installing Bundler"
-gem install --no-rdoc --no-ri bundler
+gem install --no-rdoc --no-ri bundler -v 1.16.0
 
 echo -e "\n[*] Installing Nepenthes' required gems"
-bundle install --without local
+bundle _1.16.0_ install --without local
 
 echo -e "\n[*] Dropping Nepenthes worker scripts in ~/"
 ln -s `pwd`/script/*worker*.sh ../

--- a/script/start-nepenthes-server.sh
+++ b/script/start-nepenthes-server.sh
@@ -7,10 +7,10 @@ fi
 
 cd nepenthes
 tmux new-session -s nepenthesserver -n unicorn -d \
-  'unicorn_rails -E production -c config/unicorn.rb'
+  'bundle exec unicorn_rails -E production -c config/unicorn.rb'
 tmux new-window -t nepenthesserver:1 -n results \
-  'sidekiq -e production -c 5 -q results -v'
+  'bundle exec sidekiq -e production -c 5 -q results -v'
 tmux new-window -t nepenthesserver:2 -n batch \
-  'sidekiq -e production -c 1 -q batch -v'
+  'bundle exec sidekiq -e production -c 1 -q batch -v'
 
 echo -e "\n[*] Go to http://`hostname`:8080/ to load Nepenthes."

--- a/script/start-nepenthes-worker.sh
+++ b/script/start-nepenthes-worker.sh
@@ -17,8 +17,8 @@ echo "Redis works."
 
 cd nepenthes
 tmux new-session -s nepenthes -n lomem -d \
-  'sidekiq -e sidekiq -c 20 -q lomem_fast -q lomem_slow -v'
+  'bundle exec sidekiq -e sidekiq -c 20 -q lomem_fast -q lomem_slow -v'
 tmux new-window -t nepenthes:1 -n himem \
-  'sidekiq -e sidekiq -c 2 -q himem_fast -q himem_slow -v'
+  'bundle exec sidekiq -e sidekiq -c 2 -q himem_fast -q himem_slow -v'
 
 echo -e "\n[*] Nepenthes worker running."


### PR DESCRIPTION
Updating the install and start bash scripts to utilize bundler version 1.16.0.

This will prevent any discrepancies between gem versions and will allow for a smooth/working install straight out of the box. 